### PR TITLE
Removal of lastBuilt() check processing of headers

### DIFF
--- a/src/CSPMiddleware.php
+++ b/src/CSPMiddleware.php
@@ -26,7 +26,7 @@ class CSPMiddleware implements HTTPMiddleware
         $response = $delegate($request);
 
         // Skip if we've not built the database yet or on CLI requests (e.g. first dev/build)
-        if (!DatabaseAdmin::lastBuilt() || Director::is_cli()) {
+        if (Director::is_cli()) {
             return $response;
         }
 

--- a/src/Requirements/SRIRecord.php
+++ b/src/Requirements/SRIRecord.php
@@ -46,7 +46,10 @@ class SRIRecord extends DataObject
         ])->first();
 
         if (!$record || !$record->isInDB()) {
-            $record = SRIRecord::create(['File' => $file]);
+            $record = SRIRecord::create([
+                'File' => $file,
+                'ModifiedTime' => $mTime,
+            ]);
             $record->write();
         }
 


### PR DESCRIPTION
Because apache workers will not always have the `DatabaseAdmin::lastBuilt()` tmp file for when dev/build was explicitly last ran then the logical check of `DatabaseAdmin::lastBuilt()` would return  falsey thus the CSP headers would not be processed.

The SRIRecord table was also not retaining the 'ModifiedTime' value so it could not check if previous SRIRecord record values matched the current Integrities.