### PR TITLE
GTM fragment rule updates

### DIFF
--- a/src/Fragments/GoogleTagManager.php
+++ b/src/Fragments/GoogleTagManager.php
@@ -15,6 +15,7 @@ class GoogleTagManager implements Fragment
     public static function addTo(Policy $policy): void
     {
         self::undocumented($policy);
+        self::enableGTM($policy);
         self::customJavascriptVars($policy);
         self::previewMode($policy);
         self::analytics($policy);
@@ -30,7 +31,21 @@ class GoogleTagManager implements Fragment
     {
         $policy
             ->addDirective(Directive::FRAME, '*.doubleclick.net')
-            ->addDirective(Directive::CONNECT, '*.doubleclick.net');
+            ->addDirective(Directive::CONNECT, '*.doubleclick.net')
+            ->addDirective(Directive::IMG, '*.doubleclick.net');
+    }
+
+    /*
+     * https://developers.google.com/tag-manager/web/csp#enabling_the_google_tag_manager_snippet
+     */
+    public static function enableGTM(Policy $policy): void
+    {
+        $policy
+            // Preferred approach is nonce the GoogleTagManager gtag.js script
+            // however to provide a default backup for other digital marketing tools like Adobe tag manager
+            // which can call gtag.js script without applying a nonce, whitelisting the GTM domain is required.
+            ->addDirective(Directive::SCRIPT, 'https://www.googletagmanager.com')
+            ->addDirective(Directive::IMG, 'https://www.googletagmanager.com');
     }
 
     /*


### PR DESCRIPTION
Adobe Tag manager related updates for the GoogleTagManager fragment.
- new `enableGTM()` method to setup defaults for the GTM script.
- providing default fallback of the https://www.googletagmanager.com domain under the `script-src` and `img-src` directives
- new rule for '*.doubleclick.net' domain under the `img-src` directive.