### PR TITLE
Update youtube fragment & use media fragments in CMS policy

### DIFF
--- a/src/Fragments/YouTube.php
+++ b/src/Fragments/YouTube.php
@@ -13,6 +13,10 @@ class YouTube implements Fragment
     public static function addTo(Policy $policy): void
     {
         $policy
+            // This is a CDN for youtube static assets
+            ->addDirective(Directive::IMG, [
+                '*.ytimg.com',
+            ])
             ->addDirective(Directive::SCRIPT, [
                 // The main youtube domain
                 'www.youtube.com',

--- a/src/Policies/CMS.php
+++ b/src/Policies/CMS.php
@@ -6,6 +6,8 @@ use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
 use Silverstripe\CSP\Directive;
+use Silverstripe\CSP\Fragments\Vimeo;
+use Silverstripe\CSP\Fragments\YouTube;
 use Silverstripe\CSP\Keyword;
 use Silverstripe\CSP\Scheme;
 
@@ -14,10 +16,17 @@ class CMS extends Policy
     public function configure()
     {
         $this
+            // HTML Editor used to include media
+            ->addFragments([
+                YouTube::class,
+                Vimeo::class,
+            ])
             ->addDirective(Directive::BASE, Keyword::SELF)
             ->addDirective(Directive::CONNECT, Keyword::SELF)
             ->addDirective(Directive::DEFAULT, Keyword::SELF)
             ->addDirective(Directive::FORM_ACTION, Keyword::SELF)
+            ->addDirective(Directive::FRAME, Keyword::SELF)
+            ->addDirective(Directive::CHILD, Keyword::SELF)
             ->addDirective(Directive::IMG, [
                 Keyword::SELF,
                 Scheme::DATA,


### PR DESCRIPTION
- Update to the youtube fragment to include `img-src` for Youtube assets. 
- Update CMS policy to use media fragments as HTML editor has media plugin to embed Youtube iframe.