### PR TITLE
Feature: Add support for GTM noscript iframe

### DIFF
--- a/src/Fragments/GoogleTagManager.php
+++ b/src/Fragments/GoogleTagManager.php
@@ -45,6 +45,7 @@ class GoogleTagManager implements Fragment
             // however to provide a default backup for other digital marketing tools like Adobe tag manager
             // which can call gtag.js script without applying a nonce, whitelisting the GTM domain is required.
             ->addDirective(Directive::SCRIPT, 'https://www.googletagmanager.com')
+            ->addDirective(Directive::FRAME, 'https://www.googletagmanager.com')
             ->addDirective(Directive::IMG, 'https://www.googletagmanager.com');
     }
 

--- a/tests/PolicyTest.php
+++ b/tests/PolicyTest.php
@@ -271,7 +271,7 @@ class PolicyTest extends SapphireTest
         [$request, $response] = $this->getRequestResponse();
         $policy->applyTo($response);
         $this->assertEquals(
-            'script-src www.youtube.com s.ytimg.com player.vimeo.com;frame-src *.youtube.com player.vimeo.com;child-src player.vimeo.com',
+            'img-src *.ytimg.com;script-src www.youtube.com s.ytimg.com player.vimeo.com;frame-src *.youtube.com player.vimeo.com;child-src player.vimeo.com',
             $response->getHeader('content-security-policy')
         );
     }


### PR DESCRIPTION
I'm pretty green at this stuff. I assume I need this change, but please let me know if I've got this wrong. I couldn't see `nonce` being added to the `frame-src`, so I assume this wasn't a thing?

GTM now has you include a `noscript` snippet.

```
<!-- Google Tag Manager (noscript) -->
<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXXXXXX"
height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
<!-- End Google Tag Manager (noscript) -->
```