### PR TITLE
Google Services fragment updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ public function configure(): void
 }
 ```
 
+## Google Tag Manager / Adservices whitelist
+Google uses localised regional domains for visitors for image tracker loading, which can pile up report violations with `google.com|.co.nz|.com.au` etc in your reporting tool.
+To resolve this and rather than specifying all of Google's listed support domains (see https://www.google.com/supported_domains)
+A white list config can be set to the GTM fragment to whitelist all `https:` URLs on the `img-src` directive, for example:
+```yaml
+Silverstripe\CSP\Fragments\GoogleTagManager:
+  whitelist_google_regional_domains: true
+```
+> See also ImagesOverHTTPs::class for more basic cover of https images.
+
 ## SRI
 We also support SRI in this module, you can enable this via yaml:
 ```yaml

--- a/src/Fragments/GoogleMaps.php
+++ b/src/Fragments/GoogleMaps.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\ContentSecurity\Fragments;
+
+use Silverstripe\CSP\Directive;
+use Silverstripe\CSP\Fragments\Fragment;
+use Silverstripe\CSP\Policies\Policy;
+
+/*
+ * Allows execution of Google Maps API related resources
+ * Nonce on the https://maps.google.com/maps/api/js URL is required before using this fragment.
+ *
+ * https://content-security-policy.com/examples/google-maps/
+ */
+class GoogleMaps implements Fragment
+{
+    public static function addTo(Policy $policy): void
+    {
+         $policy
+             ->addDirective(Directive::CONNECT, 'https://maps.googleapis.com')
+             ->addDirective(Directive::IMG,
+                 [
+                    'https://maps.gstatic.com',
+                    'https://*.googleapis.com',
+                    'https://*.ggpht.com'
+                 ]
+             );
+    }
+}


### PR DESCRIPTION
## Updated GoogleTagManager fragment

- explicit protocol usage in rules for Google URLs.
- additional URIs for hosts where wildcards wont match.
- updated comments to add more context and source research.
- added new google maps fragment to whitelist domains not covered in the script-src.
- added configurable setting to white Google supported domains (see https://www.google.com/supported_domains) for regional reports violation covering.

NB: Raised a request issue see #10 but ideally until I can look at that (or whomever can) a better way specify Googles regional URLs instead of fattening the headers or whitelisting all https URLs.