### PR TITLE
Bugfix: removed non secure URI

### DIFF
--- a/src/Fragments/GoogleTagManager.php
+++ b/src/Fragments/GoogleTagManager.php
@@ -42,7 +42,6 @@ class GoogleTagManager implements Fragment
                 [
                     'https://*.doubleclick.net',
                     'https://stats.g.doubleclick.net',
-                    'http://bid.g.doubleclick.net',
                 ]
             )
             ->addDirective(Directive::CONNECT, [


### PR DESCRIPTION
//bid.g.doubleclick.net is already added in `adRemarketing()`, duplicate removed from `undocumented()` as we only need https URLs.