### PR TITLE
FIX: GoogleMaps fragment Incorrect namespace usage

### DIFF
--- a/src/Fragments/GoogleMaps.php
+++ b/src/Fragments/GoogleMaps.php
@@ -1,14 +1,15 @@
 <?php
 
-namespace App\ContentSecurity\Fragments;
+namespace Silverstripe\CSP\Fragments;
 
 use Silverstripe\CSP\Directive;
-use Silverstripe\CSP\Fragments\Fragment;
 use Silverstripe\CSP\Policies\Policy;
 
 /*
  * Allows execution of Google Maps API related resources
- * Nonce on the https://maps.google.com/maps/api/js URL is required before using this fragment.
+ * Depending on how you include GoogleMaps API you will need either:
+ *  - inline script: requires nonce.
+ *  - node package in build-chain via dynamic calls: whitelist 'https://maps.google.com' via 'script-src' directive.
  *
  * https://content-security-policy.com/examples/google-maps/
  */


### PR DESCRIPTION
Incorrect namespace was applied to GoogleMaps fragment, updated to correct the namespace.

Additionally: 
 - Updated the comment to reflect that some users may include GoogleMaps as a node package and not an inline script include. 

Thus the `script-src` directive needs to be updated to include `https://maps.google.com` URI to allow for Googles CSP validation test ( `https://maps.googleapis.com/maps/api/mapsjs/gen_204?csp_test=true`), to be called before GoogleMaps will actually load.

see also comments from last version where this was resolved: https://github.com/silverstripeltd/silverstripe-csp/pull/11#discussion_r743355764