### PR TITLE
Added optional report-uri env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ public function configure(): void
 ```
 _Usually you'll define `private const FRAGMENTS = []` and add them in there so it's clear at the beginning what fragments you're adding._
 
-To set the **report to**, we usually use an env var named `CSP_REPORT_TO`. You can also call `$this->reportTo()` in your policies configure func if required (perhaps you want the report URI based on the policy applied).
+To set the **`report-to`** directive, we usually use an env var named `CSP_REPORT_TO`. You can also call `$this->reportTo()` in your policies configure func if required (perhaps you want the report URI based on the policy applied).
+
+Althought **`report-uri`** has been deprecated and is replaced by **`report-to`**, some browsers might still support it. Some CSP reporting tools might require a different API endpoint for **`report-uri`** and can be set via the `CSP_REPORT_TO_URI` env var, this is an optional env var, it will fall back to `CSP_REPORT_TO` if is not set.
 
 To add the policy to the list of applied policies you'll want to add some yaml config:
 ```yaml

--- a/src/Policies/Policy.php
+++ b/src/Policies/Policy.php
@@ -84,10 +84,10 @@ abstract class Policy
         return $this;
     }
 
-    public function reportTo(string $uri): self
+    public function reportTo(string $reportTo, string $reportToUri = ''): self
     {
-        $this->directives[Directive::REPORT] = [$uri];
-        $this->directives[Directive::REPORT_TO] = [$uri];
+        $this->directives[Directive::REPORT] = [$reportToUri ?? $reportTo];
+        $this->directives[Directive::REPORT_TO] = [$reportTo];
 
         return $this;
     }
@@ -123,8 +123,9 @@ abstract class Policy
         }
 
         $reportTo = Environment::getEnv('CSP_REPORT_TO');
+        $reportToUri = Environment::getEnv('CSP_REPORT_TO_URI');
         if (!array_key_exists(Directive::REPORT, $this->directives) && $reportTo) {
-            $this->reportTo($reportTo);
+            $this->reportTo($reportTo, $reportToUri);
         }
 
         $response->addHeader($headerName, (string) $this);

--- a/tests/PolicyTest.php
+++ b/tests/PolicyTest.php
@@ -65,6 +65,12 @@ class PolicyTest extends SapphireTest
         $policy->applyTo($response);
         $this->assertContains('report-to https://silverstripe.com', $response->getHeader('Content-Security-Policy-Report-Only'));
         $this->assertContains('report-uri https://silverstripe.com', $response->getHeader('Content-Security-Policy-Report-Only'));
+
+        $policy->reportTo('https://silverstripe.com', 'https://silverstripe.com/uri');
+        $response->removeHeader('Content-Security-Policy-Report-Only');
+        $policy->applyTo($response);
+        $this->assertContains('report-to https://silverstripe.com', $response->getHeader('Content-Security-Policy-Report-Only'));
+        $this->assertContains('report-uri https://silverstripe.com/uri', $response->getHeader('Content-Security-Policy-Report-Only'));
     }
 
     public function testIsCanUseMultipleValuesForTheSameDirective(): void


### PR DESCRIPTION
Added optional ENV variable `CSP_REPORT_TO_URI` for `report-uri` directive. If this variable is not set, it will default to existing variable `CSP_REPORT_TO`.

The reason for this is because [Raygun](https://raygun.com/documentation/language-guides/browser-reporting/crash-reporting/csp/) requires a different `report-uri` endpoint to `report-to`