### PR TITLE
Optional report-uri env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ public function configure(): void
 ```
 _Usually you'll define `private const FRAGMENTS = []` and add them in there so it's clear at the beginning what fragments you're adding._
 
-To set the **report to** url, we usually use an env var named `CSP_REPORT_TO`. The expiry time can also be set using `CSP_REPORT_TO_TTL` this tells the browser how long it should remember the url for.
+To set the **`report-to`** directive, we usually use an env var named `CSP_REPORT_TO`. You can also call `$this->reportTo()` in your policies configure func if required (perhaps you want the report URI based on the policy applied). The expiry time can also be set using `CSP_REPORT_TO_TTL` this tells the browser how long it should remember the url for.
+
+Althought **`report-uri`** has been deprecated and is replaced by **`report-to`**, some browsers might still support it. Some CSP reporting tools might require a different API endpoint for **`report-uri`** and can be set via the `CSP_REPORT_TO_URI` env var, this is an optional env var, it will fall back to `CSP_REPORT_TO` if is not set.
 
 You can also call `$this->reportTo()` in your policies configure func if required (perhaps you want the report URI based on the policy applied).
 

--- a/src/Policies/Policy.php
+++ b/src/Policies/Policy.php
@@ -91,7 +91,7 @@ abstract class Policy
      * @param string $uri - the uri to send the reports to, or empty to remove reporting
      * @return self
      */
-    public function reportTo(string $uri): self
+    public function reportTo(string $uri, string $reportToUri = ''): self
     {
         // if the string is empty, we can assume we need to _remove_ reporting
         if (empty($uri)) {
@@ -102,7 +102,7 @@ abstract class Policy
         }
 
         // Add the report-uri directive - this is deprecated, but still supported by most browsers
-        $this->directives[Directive::REPORT] = [$uri];
+        $this->directives[Directive::REPORT] = [$reportToUri ?: $uri];
 
         // Add the report-to directive - this is the new standard, but not yet supported by all browsers
         // the syntax for this will be fixed when the header is added
@@ -257,6 +257,7 @@ abstract class Policy
     private function applyReporting(HTTPResponse $response): void
     {
         $reportTo = Environment::getEnv('CSP_REPORT_TO');
+        $reportToUri = Environment::getEnv('CSP_REPORT_TO_URI');
 
         $hasEnvironmentVariable = !is_null($reportTo) && $reportTo !== false;
 
@@ -273,7 +274,7 @@ abstract class Policy
             }
 
             // otherwise add both
-            $this->reportTo($reportTo);
+            $this->reportTo($reportTo, $reportToUri);
             $this->applyReportTo($response);
             return;
         }


### PR DESCRIPTION
Added optional ENV variable CSP_REPORT_TO_URI for report-uri directive. If this variable is not set, it will default to existing variable CSP_REPORT_TO.

The reason for this is because [Raygun](https://raygun.com/documentation/language-guides/browser-reporting/crash-reporting/csp/) requires a different report-uri endpoint to report-to