### PR TITLE
Add a scheme for encrypted websockets

### DIFF
--- a/src/Scheme.php
+++ b/src/Scheme.php
@@ -9,4 +9,5 @@ abstract class Scheme
     public const HTTPS = 'https:';
     public const BLOB = 'blob:';
     public const WS = 'ws:';
+    public const WSS = 'wss:';
 }

--- a/tests/PolicyTest.php
+++ b/tests/PolicyTest.php
@@ -555,6 +555,7 @@ class PolicyTest extends SapphireTest
                     Scheme::DATA,
                     Scheme::HTTPS,
                     Scheme::WS,
+                    Scheme::WSS,
                 ]);
             }
         };
@@ -562,7 +563,7 @@ class PolicyTest extends SapphireTest
         [$request, $response] = $this->getRequestResponse();
         $policy->applyTo($response);
         $this->assertEquals(
-            'img-src data: https: ws:',
+            'img-src data: https: ws: wss:',
             $response->getHeader('content-security-policy')
         );
     }


### PR DESCRIPTION
We have `WS`, so why not `WSS`