### PR TITLE
FIX Update Nonce classes with correct namespace

### DIFF
--- a/_config/nonce.yml
+++ b/_config/nonce.yml
@@ -2,5 +2,5 @@
 Name: csp_nonce
 ---
 SilverStripe\Core\Injector\Injector:
-  Silverstripe\CSP\NonceGenerator:
-    class: Silverstripe\CSP\RandomString
+  Silverstripe\CSP\Nonce\NonceGenerator:
+    class: Silverstripe\CSP\Nonce\RandomString

--- a/src/Nonce/NonceGenerator.php
+++ b/src/Nonce/NonceGenerator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Silverstripe\CSP;
+namespace Silverstripe\CSP\Nonce;
 
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\View\TemplateGlobalProvider;

--- a/src/Nonce/RandomString.php
+++ b/src/Nonce/RandomString.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Silverstripe\CSP;
+namespace Silverstripe\CSP\Nonce;
 
 class RandomString extends NonceGenerator
 {

--- a/src/Policies/Policy.php
+++ b/src/Policies/Policy.php
@@ -10,7 +10,7 @@ use SilverStripe\Core\Environment;
 use SilverStripe\Core\Injector\Injectable;
 use Silverstripe\CSP\Directive;
 use Silverstripe\CSP\Keyword;
-use Silverstripe\CSP\NonceGenerator;
+use Silverstripe\CSP\Nonce\NonceGenerator;
 use Silverstripe\CSP\Value;
 
 abstract class Policy

--- a/src/Requirements/ContentSecurityPolicy.php
+++ b/src/Requirements/ContentSecurityPolicy.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\CSP\Requirements;
 
-use Silverstripe\CSP\NonceGenerator;
+use Silverstripe\CSP\Nonce\NonceGenerator;
 
 trait ContentSecurityPolicy
 {

--- a/tests/NonceTest.php
+++ b/tests/NonceTest.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\CSP\Tests;
 
-use Silverstripe\CSP\NonceGenerator;
+use Silverstripe\CSP\Nonce\NonceGenerator;
 use SilverStripe\Dev\SapphireTest;
 
 class NonceTest extends SapphireTest

--- a/tests/PolicyTest.php
+++ b/tests/PolicyTest.php
@@ -10,7 +10,7 @@ use Silverstripe\CSP\Directive;
 use Silverstripe\CSP\Fragments\Vimeo;
 use Silverstripe\CSP\Fragments\YouTube;
 use Silverstripe\CSP\Keyword;
-use Silverstripe\CSP\NonceGenerator;
+use Silverstripe\CSP\Nonce\NonceGenerator;
 use Silverstripe\CSP\Policies\Basic;
 use Silverstripe\CSP\Policies\CMS;
 use Silverstripe\CSP\Policies\Policy;

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -2,7 +2,7 @@
 
 namespace Silverstripe\CSP\Tests;
 
-use Silverstripe\CSP\NonceGenerator;
+use Silverstripe\CSP\Nonce\NonceGenerator;
 use Silverstripe\CSP\Requirements\CSPBackend;
 use SilverStripe\Dev\SapphireTest;
 


### PR DESCRIPTION
This was flagged by PHPStan as `class.notFound`.

```
 416    Call to static method get() on an unknown class                       
         Silverstripe\CSP\RandomString.                                        
         🪪  class.notFound                                                    
         💡  Learn more at https://phpstan.org/user-guide/discovering-symbols
```